### PR TITLE
Update climate.py

### DIFF
--- a/custom_components/neviweb130/climate.py
+++ b/custom_components/neviweb130/climate.py
@@ -50,7 +50,7 @@ PRESET_MODES = [
 ]
 
 DEVICE_MODEL_FLOOR = [737]
-DEVICE_MODEL_HEAT = [1123, 1124, 1400, 1500]
+DEVICE_MODEL_HEAT = [1123, 1124, 1400, 1500, 7372]
 IMPLEMENTED_DEVICE_MODEL = DEVICE_MODEL_HEAT + DEVICE_MODEL_FLOOR
 
 async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):


### PR DESCRIPTION
Model 7372 needs to be added to support the Thermostat basse tension intelligent 24 Vca – Zigbee -> TH1400ZB. Tested on my side and it works.