### PR TITLE
Catch Éco Sinopé signal for peak period

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,9 +139,7 @@ Automations require services to be able to send commande. Ex. light.turn_on. For
 If you have at least on thermostat or one load controler registered with Éco Sinopé program, it is now possible to catch when Neviweb send the signal for pre-heating start period for thermostats or start signal for the load controler. Three attributes have been added to know that peak period is comming:
 
 - For thermostats:
-  - eco_status: set to «off» during normal period, to «on», during pre-heat and peak period.
-  - eco_power: set to «off» during normal operation, to «on» if thermostat is heating during peak period.
-  - eco_optout: set to «off» during normal operation, to «on» during peak period if somebody have changed the setpoint on the thermostat.
+  - As to now there is no attributes available to catch peak period start.
 - For load controler:
   - eco_status: set to «off» during normal operation, to «on» during peak period.
   - eco_power: set to «off» during normal operation, to «on» during peak period.

--- a/README.md
+++ b/README.md
@@ -135,6 +135,20 @@ Automations require services to be able to send commande. Ex. light.turn_on. For
 - neviweb130.set_air_floor_mode to switch between floor or ambiant temperature sensor to control room temperature
 - neviweb130.set_phase_control to set phase control mode for DM2550ZB dimmer (reverse or forward)
 
+## Catch Éco Sinopé signal for peak period
+If you have at least on thermostat or one load controler registered with Éco Sinopé program, it is now possible to catch when Neviweb send the signal for pre-heating start period for thermostats or start signal for the load controler. Three attributes have been added to know that peak period is comming:
+
+- For thermostats:
+  - eco_status: set to «off» during normal period, to «on», during pre-heat and peak period.
+  - eco_power: set to «off» during normal operation, to «on» if thermostat is heating during peak period.
+  - eco_optout: set to «off» during normal operation, to «on» during peak period if somebody have changed the setpoint on the thermostat.
+- For load controler:
+  - eco_status: set to «off» during normal operation, to «on» during peak period.
+  - eco_power: set to «off» during normal operation, to «on» during peak period.
+  - eco_optout: set to «off» during normal operation during peak period, to «on» if somebody turn on the load controler during peak period.
+
+It is then possible to make an automation to set all devices ready for peak period.
+
 ## Troubleshooting
 if you see your device in the log but it do not apear in entity list you need to add the device model number in the code. Or you can send the model number to me so I can add it in the code.
 

--- a/custom_components/neviweb130/switch.py
+++ b/custom_components/neviweb130/switch.py
@@ -243,7 +243,7 @@ class Neviweb130Switch(SwitchEntity):
         self._timer = 0
         self._keypad = None
         self._drstatus_active = None
-        self._drstatus_out = None
+        self._drstatus_optout = None
         self._drstatus_onoff = None
         self._battery_alert = None
         self._temp_alert = None
@@ -297,7 +297,7 @@ class Neviweb130Switch(SwitchEntity):
                     self._timer = device_data[ATTR_TIMER]
                     self._onOff = device_data[ATTR_ONOFF]
                     self._drstatus_active = device_data[ATTR_DRSTATUS]["drActive"]
-                    self._drstatus_out = device_data[ATTR_DRSTATUS]["optOut"]
+                    self._drstatus_optout = device_data[ATTR_DRSTATUS]["optOut"]
                     self._drstatus_onoff = device_data[ATTR_DRSTATUS]["onOff"]
                 else: #for is_wall
                     self._current_power_w = device_data[ATTR_WATTAGE_INSTANT]
@@ -389,7 +389,7 @@ class Neviweb130Switch(SwitchEntity):
                    'Keypad': self._keypad,
                    'Timer': self._timer,
                    'drstatus_active': self._drstatus_active,
-                   'drstatus_optOut': self._drstatus_out,
+                   'drstatus_optOut': self._drstatus_optout,
                    'drstatus_onoff': self._drstatus_onoff}
         elif self._is_wifi_valve:
             data = {'Valve_status': self._valve_status,

--- a/custom_components/neviweb130/switch.py
+++ b/custom_components/neviweb130/switch.py
@@ -242,9 +242,9 @@ class Neviweb130Switch(SwitchEntity):
         self._temp_alarm = None
         self._timer = 0
         self._keypad = None
-        self._drstatus_active = None
-        self._drstatus_optout = None
-        self._drstatus_onoff = None
+        self._drstatus_active = "off"
+        self._drstatus_optout = "off"
+        self._drstatus_onoff = "off"
         self._battery_alert = None
         self._temp_alert = None
         _LOGGER.debug("Setting up %s: %s", self._name, device_info)
@@ -388,9 +388,9 @@ class Neviweb130Switch(SwitchEntity):
                    'Wattage': self._wattage,
                    'Keypad': self._keypad,
                    'Timer': self._timer,
-                   'drstatus_active': self._drstatus_active,
-                   'drstatus_optOut': self._drstatus_optout,
-                   'drstatus_onoff': self._drstatus_onoff}
+                   'eco_status': self._drstatus_active,
+                   'eco_optOut': self._drstatus_optout,
+                   'eco_onoff': self._drstatus_onoff}
         elif self._is_wifi_valve:
             data = {'Valve_status': self._valve_status,
                    'Temperature_alarm': self._temp_alarm,


### PR DESCRIPTION
In this release I've catched the Éco Sinopé signal for load controler.
For thermostats registered to Éco Sinopé I didn't find available signal but we can detect temperature increase for pre-heat and decrease for peak start.
For the load controler, as there is no pre-heating the eco_status is set to «on» more or less 10 minutes before the peak period start.
Three attributes are set, eco_status, eco_power and eco_optout for thermostats.
See the documentation.