### PR TITLE
Update climate.py

### DIFF
--- a/custom_components/neviweb130/climate.py
+++ b/custom_components/neviweb130/climate.py
@@ -890,8 +890,6 @@ class Neviweb130Thermostat(ClimateEntity):
         """Return current HVAC action."""
         if self._operation_mode == HVAC_MODE_OFF:
             return CURRENT_HVAC_OFF
-        elif self._operation_mode == MODE_AUTO_BYPASS:
-            return MODE_AUTO_BYPASS
         elif self._heat_level == 0:
             return CURRENT_HVAC_IDLE
         else:


### PR DESCRIPTION
When defined, the climate entity will have hvac_action=autoBypass for SINOPE WIFI thermostats, which breaks HASS-HOMEKIT and causes misreported heating status.

I did some behaviour testing, and observed that its not necessary to handle this state; when removed, the heating status would now be accurately reflected in HA and HomeKit when there would be real demand for heat by the thermostat.