### PR TITLE
fix: Fail at start when using ACT4220WF-M

### DIFF
--- a/custom_components/neviweb130/switch.py
+++ b/custom_components/neviweb130/switch.py
@@ -836,6 +836,7 @@ class Neviweb130Switch(SwitchEntity):
                     self._water_leak_status = device_data[ATTR_WATER_LEAK_STATUS]
                     if ATTR_FLOW_ALARM_TIMER in device_data:
                         self._flowmeter_timer = device_data[ATTR_FLOW_ALARM_TIMER]
+                    if ATTR_FLOW_THRESHOLD in device_data:
                         self._flowmeter_threshold = device_data[ATTR_FLOW_THRESHOLD]
                         self._flowmeter_alert_delay = neviweb_to_ha_delay(device_data[ATTR_FLOW_ALARM1_PERIOD])
                         self._flowmeter_alarm_lenght = device_data[ATTR_FLOW_ALARM1_LENGHT]
@@ -862,6 +863,7 @@ class Neviweb130Switch(SwitchEntity):
                     self._water_leak_status = device_data[ATTR_WATER_LEAK_STATUS]
                     if ATTR_FLOW_ALARM_TIMER in device_data:
                         self._flowmeter_timer = device_data[ATTR_FLOW_ALARM_TIMER]
+                    if ATTR_FLOW_THRESHOLD in device_data:
                         self._flowmeter_threshold = device_data[ATTR_FLOW_THRESHOLD]
                         self._flowmeter_alert_delay = neviweb_to_ha_delay(device_data[ATTR_FLOW_ALARM1_PERIOD])
                         self._flowmeter_alarm_lenght = device_data[ATTR_FLOW_ALARM1_LENGHT]


### PR DESCRIPTION
When using with a ACT4220WF-M sedna multi-residential valve 2gen, the integration fails to start with this in the log:

```
2023-03-28 22:40:32.761 ERROR (MainThread) [homeassistant.components.switch] neviweb130: Error on device update!
Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/helpers/entity_platform.py", line 493, in _async_add_entity
    await entity.async_device_update(warning=False)
  File "/usr/src/homeassistant/homeassistant/helpers/entity.py", line 715, in async_device_update
    await task
  File "/usr/local/lib/python3.10/concurrent/futures/thread.py", line 58, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/config/custom_components/neviweb130/switch.py", line 865, in update
    self._flowmeter_threshold = device_data[ATTR_FLOW_THRESHOLD]
KeyError: 'alarm1FlowThreshold'
```

dumping the `device_data` in the log shows:

```
{
	"onOff": "on",
	"batteryVoltage": 6.9,
	"batteryStatus": "ok",
	"stm8Error": {
		"motorJam": false,
		"motorPosition": false,
		"motorLimit": false
	},
	"waterLeakStatus": "flowMeter",
	"flowMeterMeasurementConfig": {
		"multiplier": 0,
		"offset": 0,
		"divisor": 1
	},
	"flowMeterAlarmDisableTimer": 0
}
```

Note: This is only a quick patch that fixes the issue on my side, probably not the right way to do that.
Note2: Reverting back to 1.9.7 fixes the issue.