### PR TITLE
Correcting Errors/Warning found during integration

### DIFF
--- a/custom_components/neviweb130/climate.py
+++ b/custom_components/neviweb130/climate.py
@@ -1051,9 +1051,9 @@ class Neviweb130Thermostat(ClimateEntity):
         elif device_data["error"]["code"] == "DVCCOMMTO":
             _LOGGER.warning("Device Communication Timeout... The device did not respond to the server within the prescribed delay.")
         elif device_data["error"]["code"] == "DVCUNVLB":
-            _LOGGER.warning("Device %s unavailable, check your network...%s". self._name, device_data)
+            _LOGGER.warning("Device %s unavailable, check your network...%s", self._name, device_data)
         elif device_data["error"]["code"] == "DVCATTRNSPTD":
-            _LOGGER.warning("Device attribute not supported for %s: %s...(SKU: %s)". self._name, device_data, self._sku)
+            _LOGGER.warning("Device attribute not supported for %s: %s...(SKU: %s)", self._name, device_data, self._sku)
         else:
             _LOGGER.warning("Unknown error for %s: %s...(SKU: %s) Report to maintainer.", self._name, device_data, self._sku)
         if self._sku != "FLP55":

--- a/custom_components/neviweb130/light.py
+++ b/custom_components/neviweb130/light.py
@@ -359,13 +359,13 @@ class Neviweb130Light(LightEntity):
             else:
                 _LOGGER.warning("Got None for device_hourly_stats")
             device_daily_stats = self._client.get_device_daily_stats(self._id)
-            if device_daily_stats is not None:
+            if device_daily_stats is not None and len(device_daily_stats) > 1:
                 self._today_energy_kwh_count = device_daily_stats[0]["counter"] / 1000
                 self._today_kwh = device_daily_stats[0]["period"] / 1000
             else:
                 _LOGGER.warning("Got None for device_daily_stats")
             device_monthly_stats = self._client.get_device_monthly_stats(self._id)
-            if device_monthly_stats is not None:
+            if device_monthly_stats is not None and len(device_monthly_stats) > 1:
                 self._month_energy_kwh_count = device_monthly_stats[0]["counter"] / 1000
                 self._month_kwh = device_monthly_stats[0]["period"] / 1000
             else:

--- a/custom_components/neviweb130/services.yaml
+++ b/custom_components/neviweb130/services.yaml
@@ -79,7 +79,7 @@ set_temperature_format:
       example: "celsius"
 
 set_led_indicator:
-  description: Set led indicator intensity an color for each light state, on/off.
+  description: Set led indicator intensity and color for each light state, on/off.
   fields:
     entity_id:
       description: Name(s) of neviweb130 device to set the led indicator color and intensity.
@@ -91,7 +91,7 @@ set_led_indicator:
       description: 0 = off, 1 to 100 intensity.
       example: 50
     red:
-      description: 0 to 255 RGB reb color indice.
+      description: 0 to 255 RGB red color indice.
       example: 25
     green:
       description: 0 to 255 RGB green color indice.
@@ -179,7 +179,7 @@ set_sensor_alert:
       description: Set to 1, send alert or 0, do nothing.
       example: 1
     cfgValveClosure:
-      description: Set to «on», close the valve when leak is detected or «off», do nothing. Leak sensor not connected to Sedna valve will not close the valve on leak detection. You will need to catch that allert and do an automation to close the valve.
+      description: Set to «on», close the valve when leak is detected or «off», do nothing. Leak sensor not connected to Sedna valve will not close the valve on leak detection. You will need to catch that alert and do an automation to close the valve.
       example: "on"
 
 set_valve_alert:
@@ -213,13 +213,13 @@ set_early_start:
       example: "on"
 
 set_air_floor_mode:
-  description: Set floor thermostat control mode via Ambiant or Floor temperature sensor.
+  description: Set floor thermostat control mode via Ambient or Floor temperature sensor.
   fields:
     entity_id:
       description: Name(s) of neviweb130 floor thermostat.
       example: "climate.neviweb130_climate_kitchen"
     airFloorMode:
-      description: Set to «airByFloor» (zigbee) or «roomByFloor» (wifi) for ambiant temperature sensor or to «floor» for floor temperature sensor.
+      description: Set to «airByFloor» (zigbee) or «roomByFloor» (wifi) for ambient temperature sensor or to «floor» for floor temperature sensor.
       example: "floor"
 
 set_phase_control:
@@ -262,7 +262,7 @@ set_hvac_dr_setpoint:
       example: -10
 
 set_load_dr_options:
-  description: Set demand response attributes for load controler in Éco Sinopé mode.
+  description: Set demand response attributes for load controller in Éco Sinopé mode.
   fields:
     entity_id:
       description: Name(s) of neviweb130 thermostats.
@@ -277,7 +277,7 @@ set_load_dr_options:
       description: Set to «on» or «off» to activate Éco Sinopé power on/off control.
       example: "on"
 
-set_control_onOff:
+set_control_onoff:
   description: Set valve controller onOff and onOff2 output status.
   fields:
     entity_id:
@@ -310,7 +310,7 @@ set_cycle_output:
       description: Name(s) of neviweb130 thermostat.
       example: "climate.neviweb130_climate_kitchen"
     value:
-      description: cycle lencht in minutes. Accepted values are "15 sec", "5 min", "10 min", "15 min", "20 min", "25 min", "30 min".
+      description: cycle length in minutes. Accepted values are "15 sec", "5 min", "10 min", "15 min", "20 min", "25 min", "30 min".
       example: "10 min"
 
 set_aux_cycle_output:
@@ -323,7 +323,7 @@ set_aux_cycle_output:
       description: Set to «on» or «off» to change status of auxiliary cycle length.
       example: "on"
     value:
-      description: cycle lencht in minutes. Accepted values are "15 sec", "5 min", "10 min", "15 min", "20 min", "25 min", "30 min".
+      description: cycle length in minutes. Accepted values are "15 sec", "5 min", "10 min", "15 min", "20 min", "25 min", "30 min".
       example: "10 min"
 
 set_battery_type:
@@ -333,7 +333,7 @@ set_battery_type:
       description: Name(s) of neviweb130 leak sensor.
       example: "sensor.neviweb130_sensor_water_tank"
     batteryType:
-      description: Set to «alkaline» or to «lithium». Original battery type are alkaline for leak sensors.
+      description: Set to «alkaline» or to «lithium». Original battery type is alkaline for leak sensors.
       example: "lithium"
 
 set_pump_protection:
@@ -347,7 +347,7 @@ set_pump_protection:
       example: "on"
 
 set_tank_size:
-  description: Set water heater tank size for RM3500ZB Calypso load controler.
+  description: Set water heater tank size for RM3500ZB Calypso load controller.
   fields:
     entity_id:
       description: Name(s) of neviweb130 switch.
@@ -357,7 +357,7 @@ set_tank_size:
       example: "80 gal"
 
 set_controlled_device:
-  description: Set device type controlled by RM3250ZB load controler.
+  description: Set device type controlled by RM3250ZB load controller.
   fields:
     entity_id:
       description: Name(s) of neviweb130 switch.
@@ -397,30 +397,30 @@ set_low_temp_protection:
       example: 45
 
 set_flow_meter_model:
-  description: Set Sedna 2e gen flow meter model and turn on/off flow meter protection.
+  description: Set Sedna 2nd gen flow meter model and turn on/off flow meter protection.
   fields:
     entity_id:
-      description: Name(s) of neviweb130 Sedna 2e gen device (VA4220ZB).
+      description: Name(s) of neviweb130 Sedna 2nd gen device (VA4220ZB).
       example: "switch.neviweb130_switch_VA4220ZB"
     FlowModel:
       description: set to FS4220, or FS4221 or  No flow meter.
       example: "No flow meter"
 
 set_flow_meter_delay:
-  description: Set Sedna 2e gen flow meter delay before leak alarm is turned on.
+  description: Set Sedna 2nd gen flow meter delay before leak alarm is turned on.
   fields:
     entity_id:
-      description: Name(s) of neviweb130 Sedna 2e gen device (VA4220ZB).
+      description: Name(s) of neviweb130 Sedna 2nd gen device (VA4220ZB).
       example: "switch.neviweb130_switch_VA4220ZB"
     alarm1Period:
       description: set to 15 min, 30 min, 45 min, 60 min, 75 min, 90 min, 3 h, 6 h, 12 h, and 24 h.
       example: "60 min"
 
 set_flow_meter_options:
-  description: Set Sedna 2e gen flow meter action in case of leak detection.
+  description: Set Sedna 2nd gen flow meter action in case of leak detection.
   fields:
     entity_id:
-      description: Name(s) of neviweb130 Sedna 2e gen device (VA4220ZB).
+      description: Name(s) of neviweb130 Sedna 2nd gen device (VA4220ZB).
       example: "switch.neviweb130_switch_VA4220ZB"
     triggerAlarm:
       description: send leak alert, on/off.


### PR DESCRIPTION
I have a SW2500ZB zigbee switch and a TH1124ZB thermostat with old firmware.  I just purchased the GT130 gateway and am in the process of integrating your component. I investigated some errors and made minor corrections to some files:

Error/Warning Corrected:
- Unable to parse services.yaml for component nevivweb130
- Error in Climate.py when this Warning is raised: Device attribute not supported for neviweb130 climate Chauffage Salle d'exercices: {'error': {'code': 'DVCATTRNSPTD', 'data': {'identifier': '14b457fffe7a95f0-500b9140000114f7'}}}...(SKU: TH1124ZB)
- Error in light.py when this warning is raised Got None for device_daily_stats

Question:  Do you have an idea how long it takes before the Firmware gets updated?  Currently over 24h and no change.