### PR TITLE
Fix network typo

### DIFF
--- a/custom_components/neviweb130/__init__.py
+++ b/custom_components/neviweb130/__init__.py
@@ -249,7 +249,7 @@ class Neviweb130Client(object):
             if self._network_name == None and self._network_name2 == None: # Use 1st network found and second if found
                 self._gateway_id = networks[0]["id"]
                 self._network_name = networks[0]["name"]
-                self._occupancyMode = network[0]["mode"]
+                self._occupancyMode = networks[0]["mode"]
                 _LOGGER.debug("Selecting %s as first network", self._network_name)
                 if len(networks) > 1:
                     self._gateway_id2 = networks[1]["id"]


### PR DESCRIPTION
Fix typo in latest release

```
2024-02-09 19:57:06.547 ERROR (MainThread) [homeassistant.setup] Error during setup of component neviweb130
Traceback (most recent call last):
File "/usr/src/homeassistant/homeassistant/setup.py", line 333, in _async_setup_component
result = await task
^^^^^^^^^^
File "/usr/local/lib/python3.12/concurrent/futures/thread.py", line 58, in run
result = self.fn(*self.args, **self.kwargs)
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "/config/custom_components/neviweb130/__init__.py", line 135, in setup
data = Neviweb130Data(hass_config[DOMAIN])
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "/config/custom_components/neviweb130/__init__.py", line 168, in __init__
self.neviweb130_client = Neviweb130Client(username, password, network, network2)
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "/config/custom_components/neviweb130/__init__.py", line 199, in __init__
self.__get_network()
File "/config/custom_components/neviweb130/__init__.py", line 252, in __get_network
self._occupancyMode = network[0]["mode"]
^^^^^^^
UnboundLocalError: cannot access local variable 'network' where it is not associated with a value
```