### PR TITLE
Use JSON parameter for initialization login request

### DIFF
--- a/custom_components/neviweb130/__init__.py
+++ b/custom_components/neviweb130/__init__.py
@@ -212,7 +212,7 @@ class Neviweb130Client(object):
         data = {"username": self._email, "password": self._password, 
             "interface": "neviweb", "stayConnected": 1}
         try:
-            raw_res = requests.post(LOGIN_URL, data=data, 
+            raw_res = requests.post(LOGIN_URL, json=data, 
                 cookies = self._cookies, allow_redirects=False, 
                 timeout = self._timeout)
         except OSError:


### PR DESCRIPTION
### Description

Fixed authentication issue preventing the API to connect to Neviweb. Fixes #255 

### Changes Made
- Use `json` parameter for the login request at initialization