### PR TITLE
Fix support of ACT4220WF-M

### DIFF
--- a/custom_components/neviweb130/valve.py
+++ b/custom_components/neviweb130/valve.py
@@ -1553,7 +1553,10 @@ class Neviweb130MeshValve(Neviweb130Valve):
                         )
                     if ATTR_FLOW_ALARM_TIMER in device_data:
                         self._flowmeter_timer = device_data[ATTR_FLOW_ALARM_TIMER]
-                        if self._flowmeter_timer == 0 and ATTR_FLOW_THRESHOLD in device_data:
+                        if (
+                            self._flowmeter_timer == 0
+                            and ATTR_FLOW_THRESHOLD in device_data
+                        ):
                             self._flowmeter_threshold = device_data[ATTR_FLOW_THRESHOLD]
                             self._flowmeter_alert_delay = device_data[
                                 ATTR_FLOW_ALARM1_PERIOD
@@ -1820,7 +1823,10 @@ class Neviweb130WifiMeshValve(Neviweb130Valve):
                         )
                     if ATTR_FLOW_ALARM_TIMER in device_data:
                         self._flowmeter_timer = device_data[ATTR_FLOW_ALARM_TIMER]
-                        if self._flowmeter_timer == 0 and ATTR_FLOW_THRESHOLD in device_data:
+                        if (
+                            self._flowmeter_timer == 0
+                            and ATTR_FLOW_THRESHOLD in device_data
+                        ):
                             self._flowmeter_threshold = device_data[ATTR_FLOW_THRESHOLD]
                             self._flowmeter_alert_delay = device_data[
                                 ATTR_FLOW_ALARM1_PERIOD


### PR DESCRIPTION
With recent versions, the integration is not able to support ACT4220WF-M valves because the `ATTR_FLOW_THRESHOLD` is not present in `device_data`.

This makes sure to not try to read such data in that case.