### PR TITLE
Fixed CI for V2-update

### DIFF
--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -18,7 +18,7 @@ jobs:
         run: uv python install
 
       - name: Install the project and dependencies
-        run: uv sync --frozen --group dev
+        run: uv sync --frozen --only-group ci
 
       - name: Run mypy
-        run: uv run --frozen --group dev mypy custom_components/neviweb130
+        run: uv run --frozen --only-group ci mypy .

--- a/custom_components/neviweb130/__init__.py
+++ b/custom_components/neviweb130/__init__.py
@@ -34,7 +34,10 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     _LOGGER.info(STARTUP_MESSAGE)
 
     neviweb130_config: ConfigType | None = config.get(DOMAIN)
-    _LOGGER.debug("Config found: %s", neviweb130_config)
+    if neviweb130_config is not None:
+        _LOGGER.debug(
+            "Config found: %s", {key: (value if key != "password" else "*") for key, value in neviweb130_config.items()}
+        )
     hass.data.setdefault(DOMAIN, {})
 
     if not neviweb130_config:

--- a/custom_components/neviweb130/config_flow.py
+++ b/custom_components/neviweb130/config_flow.py
@@ -199,7 +199,7 @@ class Neviweb130ConfigFlow(ConfigFlow, domain=DOMAIN):
             self.data = user_input
             result = await self.async_set_unique_id(user_input[CONF_USERNAME].strip().lower())
             _LOGGER.debug("Configure entry unique_id: %s", result)
-            self._abort_if_unique_id_configured(reason="already_configured_for_this_user")
+            self._abort_if_unique_id_configured(error="already_configured_for_this_user")
             return cast(ConfigFlowResult, self.async_create_entry(title="Sinope Neviweb130", data=self.data))
 
         return cast(ConfigFlowResult, self.async_show_form(step_id="user", data_schema=FLOW_SCHEMA, errors=errors))

--- a/custom_components/neviweb130/light.py
+++ b/custom_components/neviweb130/light.py
@@ -887,6 +887,7 @@ class Neviweb130Light(CoordinatorEntity, LightEntity):
                 )
                 await async_add_data(
                     self._conf_dir,
+                    self._device_dict,
                     self._id,
                     self._total_kwh_count,
                     self._marker,

--- a/custom_components/neviweb130/manifest.json
+++ b/custom_components/neviweb130/manifest.json
@@ -3,11 +3,10 @@
   "name": "Sinope Neviweb130",
   "codeowners": ["@claudegel"],
   "config_flow": true,
-  "dependencies": [],
   "documentation": "https://github.com/claudegel/sinope-130",
   "integration_type": "hub",
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/claudegel/sinope-130/issues",
-  "requirements": [],
+  "requirements": ["aiofiles"],
   "version": "4.0.0"
 }

--- a/custom_components/neviweb130/number.py
+++ b/custom_components/neviweb130/number.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
-from typing import Final
+from typing import Final, override
 
 from homeassistant.components.number import NumberEntity, NumberEntityDescription
 from homeassistant.components.number.const import NumberDeviceClass, NumberMode
@@ -373,8 +373,8 @@ class Neviweb130DeviceAttributeNumber(CoordinatorEntity[Neviweb130Coordinator], 
         """Return the state attributes of the number."""
         return {"device_id": self._attr_unique_id}
 
-    # TODO: marked @final in HomeAssistant, we should find an alternative
-    async def async_set_value(self, value: float) -> None:
+    @override
+    async def async_set_native_value(self, value: float) -> None:
         """Change the selected number value."""
         handler = self._ATTRIBUTE_METHODS.get(self._attribute)
 

--- a/custom_components/neviweb130/sensor.py
+++ b/custom_components/neviweb130/sensor.py
@@ -20,7 +20,7 @@ import logging
 import time
 from dataclasses import dataclass
 from datetime import datetime
-from typing import Any, Callable
+from typing import Any, Callable, override
 
 from homeassistant.components.binary_sensor import BinarySensorDeviceClass
 from homeassistant.components.persistent_notification import DOMAIN as PN_DOMAIN
@@ -721,7 +721,7 @@ class Neviweb130Sensor(CoordinatorEntity, SensorEntity):
         self._battery_status = None
         self._temp_status = None
         self._battery_type = "alkaline"
-        self._leak_status: str | None = None
+        self._leak_status: str = ""
         self._leak_alert = None
         self._temp_alert = None
         self._battery_alert = None
@@ -733,7 +733,7 @@ class Neviweb130Sensor(CoordinatorEntity, SensorEntity):
         self._sampling = None
         self._tank_type = None
         self._tank_height = None
-        self._tank_percent: str | None = None
+        self._tank_percent: str = ""
         self._gauge_type = None
         self._batt_percent_normal = None
         self._batt_status_normal = None
@@ -945,9 +945,9 @@ class Neviweb130Sensor(CoordinatorEntity, SensorEntity):
         """Return the current battery status."""
         return self._battery_status
 
-    # TODO: state marked @final in SensorEntity, we should find an alternative
     @property
-    def state(self) -> Any:
+    @override
+    def native_value(self) -> str:
         """Return the state of the sensor."""
         return self._leak_status
 
@@ -1112,7 +1112,7 @@ class Neviweb130ConnectedSensor(Neviweb130Sensor):
         self._battery_status = None
         self._temp_status = None
         self._battery_type = "alkaline"
-        self._leak_status = None
+        self._leak_status = ""
         self._leak_alert = None
         self._temp_alert = None
         self._battery_alert = None
@@ -1124,7 +1124,7 @@ class Neviweb130ConnectedSensor(Neviweb130Sensor):
         self._sampling = None
         self._tank_type = None
         self._tank_height = None
-        self._tank_percent = None
+        self._tank_percent = ""
         self._gauge_type = None
         self._batt_percent_normal = None
         self._batt_status_normal = None
@@ -1264,7 +1264,7 @@ class Neviweb130TankSensor(Neviweb130Sensor):
         self._snooze = 0
         self._angle = None
         self._sampling = None
-        self._tank_percent: str | None = None
+        self._tank_percent: str = ""
         self._tank_type = None
         self._tank_height = None
         self._gauge_type = None
@@ -1446,9 +1446,9 @@ class Neviweb130TankSensor(Neviweb130Sensor):
         )
         return data
 
-    # TODO: state marked @final in SensorEntity, we should find an alternative
     @property
-    def state(self) -> str | None:
+    @override
+    def native_value(self) -> str:
         """Return the state of the tank sensor."""
         return self._tank_percent
 
@@ -1516,7 +1516,7 @@ class Neviweb130GatewaySensor(Neviweb130Sensor):
         self._location = location
         self._active = True
         self._snooze = 0
-        self._gateway_status: str | None = None
+        self._gateway_status: str = ""
         self._occupancyMode = None
         self._is_gateway = device_info["signature"]["model"] in IMPLEMENTED_GATEWAY
         _LOGGER.debug("Setting up %s: %s", self._name, device_info)
@@ -1550,9 +1550,9 @@ class Neviweb130GatewaySensor(Neviweb130Sensor):
         """Return current gateway status: 'online' or 'offline'."""
         return self._gateway_status is not None
 
-    # TODO: state marked @final in HomeAssistant, we should find an alternative
     @property
-    def state(self) -> str | None:
+    @override
+    def native_value(self) -> str:
         """Return the state of the gateway."""
         return self._gateway_status
 
@@ -1621,7 +1621,6 @@ class Neviweb130DeviceAttributeSensor(CoordinatorEntity[Neviweb130Coordinator], 
         self._device_name = device_name
         self._attribute = entity_description.key
         self._device_id = device_id
-        self._native_value = None
         self._attr_unique_id = f"{self._device_id}_{entity_description.key}"
         self._attr_device_info = attr_info
         self._attr_friendly_name = f"{self._device.get('friendly_name')} {attribute.replace('_', ' ').capitalize()}"
@@ -1641,6 +1640,7 @@ class Neviweb130DeviceAttributeSensor(CoordinatorEntity[Neviweb130Coordinator], 
         return self._device_id
 
     @property
+    @override
     def native_value(self):
         """Return the state of the attribute sensor."""
         device_obj = self.coordinator.data.get(self._id)

--- a/custom_components/neviweb130/switch.py
+++ b/custom_components/neviweb130/switch.py
@@ -1222,6 +1222,7 @@ class Neviweb130Switch(CoordinatorEntity, SwitchEntity):
                 )
                 await async_add_data(
                     self._conf_dir,
+                    self._device_dict,
                     self._id,
                     self._total_kwh_count,
                     self._marker,

--- a/custom_components/neviweb130/valve.py
+++ b/custom_components/neviweb130/valve.py
@@ -964,6 +964,7 @@ class Neviweb130Valve(CoordinatorEntity, ValveEntity):
                     )
                     await async_add_data(
                         self._conf_dir,
+                        self._device_dict,
                         self._id,
                         self._total_kwh_count,
                         self._marker,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "neviweb130"
 version = "2.0"
 description = "Sinope Neviweb130: Home assistant custom_components to manage Sinopé Zigbee and Wi-Fi devices."
 authors = [{ name = "Claude Gélinas", email = "claude@phyto.qc.ca" }]
-requires-python = ">=3.12"
+requires-python = ">=3.13.2"
 readme = "README.md"
 license = { text = "Apache-2.0" }
 
@@ -12,11 +12,15 @@ repository = "https://github.com/claudegel/sinope-130"
 
 [dependency-groups]
 dev = [
-    "aiofiles~=24.1.0",
+    "isal~=1.7.1",
+    "pre-commit",
     "types-aiofiles~=24.1.0",
     "homeassistant-stubs~=2025.9.4",
+]
+ci = [
     "mypy",
-    "pre-commit",
+    "types-aiofiles~=24.1.0",
+    "homeassistant-stubs~=2025.9.4",
 ]
 
 [tool.hatch.build.targets.sdist]
@@ -31,7 +35,7 @@ build-backend = "hatchling.build"
 
 [tool.black]
 line-length = 120
-target-version = ["py312"]
+target-version = ["py313"]
 
 [tool.isort]
 profile = "black"
@@ -41,7 +45,7 @@ line_length = 120
 max-line-length = 120
 
 [tool.mypy]
-python_version = "3.12"
+python_version = "3.13"
 check_untyped_defs = true
 warn_unused_ignores = true
 show_error_codes = true
@@ -49,10 +53,10 @@ show_error_codes = true
 [tool.ruff]
 line-length = 120
 fix = true
-target-version = "py312"
+target-version = "py313"
 
 [tool.pyupgrade]
-py312plus = true
+py313plus = true
 
 [tool.codespell]
 skip = "Contributors.md,custom_components/neviweb130/translations/*.json"

--- a/uv.lock
+++ b/uv.lock
@@ -35,15 +35,6 @@ wheels = [
 ]
 
 [[package]]
-name = "aiofiles"
-version = "24.1.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/0b/03/a88171e277e8caa88a4c77808c20ebb04ba74cc4681bf1e9416c862de237/aiofiles-24.1.0.tar.gz", hash = "sha256:22a075c9e5a3810f0c2e48f3008c94d68c65d763b9b03857924c99e57355166c", size = 30247, upload-time = "2024-06-24T11:02:03.584Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/a5/45/30bb92d442636f570cb5651bc661f52b610e2eec3f891a5dc3a4c3667db0/aiofiles-24.1.0-py3-none-any.whl", hash = "sha256:b4ec55f4195e3eb5d7abd1bf7e061763e864dd4954231fb8539a0ef8bb8260e5", size = 15896, upload-time = "2024-06-24T11:02:01.529Z" },
-]
-
-[[package]]
 name = "aiohappyeyeballs"
 version = "2.6.1"
 source = { registry = "https://pypi.org/simple" }
@@ -849,21 +840,6 @@ wheels = [
 ]
 
 [[package]]
-name = "hatchling"
-version = "1.27.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "packaging" },
-    { name = "pathspec" },
-    { name = "pluggy" },
-    { name = "trove-classifiers" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/8f/8a/cc1debe3514da292094f1c3a700e4ca25442489731ef7c0814358816bb03/hatchling-1.27.0.tar.gz", hash = "sha256:971c296d9819abb3811112fc52c7a9751c8d381898f36533bb16f9791e941fd6", size = 54983, upload-time = "2024-12-15T17:08:11.894Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/08/e7/ae38d7a6dfba0533684e0b2136817d667588ae3ec984c1a4e5df5eb88482/hatchling-1.27.0-py3-none-any.whl", hash = "sha256:d3a2f3567c4f926ea39849cdf924c7e99e6686c9c8e288ae1037c8fa2a5d937b", size = 75794, upload-time = "2024-12-15T17:08:10.364Z" },
-]
-
-[[package]]
 name = "home-assistant-bluetooth"
 version = "1.13.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1205,9 +1181,6 @@ wheels = [
 name = "neviweb130"
 version = "2.0"
 source = { editable = "." }
-dependencies = [
-    { name = "hatchling" },
-]
 
 [package.dev-dependencies]
 ci = [
@@ -1216,8 +1189,6 @@ ci = [
     { name = "types-aiofiles" },
 ]
 dev = [
-    { name = "aiofiles" },
-    { name = "homeassistant" },
     { name = "homeassistant-stubs" },
     { name = "isal" },
     { name = "pre-commit" },
@@ -1225,7 +1196,6 @@ dev = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "hatchling", specifier = ">=1.27.0" }]
 
 [package.metadata.requires-dev]
 ci = [
@@ -1234,8 +1204,6 @@ ci = [
     { name = "types-aiofiles", specifier = "~=24.1.0" },
 ]
 dev = [
-    { name = "aiofiles", specifier = "~=24.1.0" },
-    { name = "homeassistant", specifier = "~=2025.9.4" },
     { name = "homeassistant-stubs", specifier = "~=2025.9.4" },
     { name = "isal", specifier = "~=1.7.1" },
     { name = "pre-commit" },
@@ -1365,15 +1333,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/23/e8/21db9c9987b0e728855bd57bff6984f67952bea55d6f75e055c46b5383e8/platformdirs-4.4.0.tar.gz", hash = "sha256:ca753cf4d81dc309bc67b0ea38fd15dc97bc30ce419a7f58d13eb3bf14c4febf", size = 21634, upload-time = "2025-08-26T14:32:04.268Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/40/4b/2028861e724d3bd36227adfa20d3fd24c3fc6d52032f4a93c133be5d17ce/platformdirs-4.4.0-py3-none-any.whl", hash = "sha256:abd01743f24e5287cd7a5db3752faf1a2d65353f38ec26d98e25a6db65958c85", size = 18654, upload-time = "2025-08-26T14:32:02.735Z" },
-]
-
-[[package]]
-name = "pluggy"
-version = "1.6.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
 ]
 
 [[package]]
@@ -1849,15 +1808,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ab/e2/e9a00f0ccb71718418230718b3d900e71a5d16e701a3dae079a21e9cd8f8/text-unidecode-1.3.tar.gz", hash = "sha256:bad6603bb14d279193107714b288be206cac565dfa49aa5b105294dd5c4aab93", size = 76885, upload-time = "2019-08-30T21:36:45.405Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a6/a5/c0b6468d3824fe3fde30dbb5e1f687b291608f9473681bbf7dabbf5a87d7/text_unidecode-1.3-py2.py3-none-any.whl", hash = "sha256:1311f10e8b895935241623731c2ba64f4c455287888b18189350b67134a822e8", size = 78154, upload-time = "2019-08-30T21:37:03.543Z" },
-]
-
-[[package]]
-name = "trove-classifiers"
-version = "2025.9.11.17"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ca/9a/778622bc06632529817c3c524c82749a112603ae2bbcf72ee3eb33a2c4f1/trove_classifiers-2025.9.11.17.tar.gz", hash = "sha256:931ca9841a5e9c9408bc2ae67b50d28acf85bef56219b56860876dd1f2d024dd", size = 16975, upload-time = "2025-09-11T17:07:50.97Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/e1/85/a4ff8758c66f1fc32aa5e9a145908394bf9cf1c79ffd1113cfdeb77e74e4/trove_classifiers-2025.9.11.17-py3-none-any.whl", hash = "sha256:5d392f2d244deb1866556457d6f3516792124a23d1c3a463a2e8668a5d1c15dd", size = 14158, upload-time = "2025-09-11T17:07:49.886Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
This is what I had to do in order to have the CI steps pass in #376 :
 - Created a new dependency group in pyproject.yaml used only by the workflows, to avoid installing dev-dependencies in the CI
 - Fixed dependency to python 3.13, homeassistant has a dependency to 3.13.2 since 2025.9, unless we downgrade we must also upgrade to 3.13.2+
 - Realigned dependencies in .github/workflows/mypy.yml
 - Fixed all new mypy issues, including the overriden methods flagged `@final` in homeassistant. I found out that overriding native_value probably has the same effect.