### PR TITLE
Raise on Neviweb write errors instead of silently dropping them (fixes #515)

### DIFF
--- a/custom_components/neviweb130/__init__.py
+++ b/custom_components/neviweb130/__init__.py
@@ -2287,6 +2287,7 @@ class Neviweb130Client:
         """Set devices attributes."""
         increment_request_counter(self.hass)
         result = 1
+        last_error: dict[str, Any] | None = None
         while result < 4:
             try:
                 resp = requests.put(
@@ -2310,12 +2311,13 @@ class Neviweb130Client:
                 _LOGGER.debug("Text = %s", resp.text)
 
                 if "error" not in resp.json():
-                    break
+                    return
 
                 result += 1
+                last_error = resp.json()
                 _LOGGER.debug(
                     "Service error received: %s, resending requests %s",
-                    resp.json(),
+                    last_error,
                     result,
                 )
             except OSError:
@@ -2328,6 +2330,25 @@ class Neviweb130Client:
                         data=data,
                     )
                 )
+        # All 3 attempts returned a Neviweb error payload: raise instead of
+        # silently dropping the write, otherwise service calls report
+        # success while the device never received the change (#515).
+        _LOGGER.warning(
+            "Failed to set attributes on device %s after 3 attempts: %s (payload: %s)",
+            device_id,
+            last_error,
+            data,
+        )
+        raise PyNeviweb130Error(
+            translated_or_default(
+                self.hass,
+                "set_attribute_failed",
+                f"Cannot set device {device_id} attributes: {data}. Neviweb returned: {last_error}.",
+                id=device_id,
+                data=data,
+                error=last_error,
+            )
+        )
 
     def post_neviweb_status(self, location: int | str, mode: str):
         """Send post requests to Neviweb for global occupancy mode"""

--- a/custom_components/neviweb130/strings.json
+++ b/custom_components/neviweb130/strings.json
@@ -59,7 +59,8 @@
       "update_fail": "Update to version {version} failed.\nA rollback was performed and the old version was restored.\n[See update notes]({url}).",
       "rollback_skip": "Update to version {version} failed.\nRollback skipped, no local backup available.\n{message}.",
       "error_resolved": "All errors resolved for device {name}, ID: {id}, Sku: {sku}.",
-      "safe_mode_enabled": "Auto-enabling safe mode for device {name} (id: {id}) due to unsupported attribute."
+      "safe_mode_enabled": "Auto-enabling safe mode for device {name} (id: {id}) due to unsupported attribute.",
+      "set_attribute_failed": "Cannot set device {id} attributes: {data}. Neviweb returned: {error}."
     }
   }
 }

--- a/custom_components/neviweb130/translations/en.json
+++ b/custom_components/neviweb130/translations/en.json
@@ -59,7 +59,8 @@
       "update_fail": "Update to version {version} failed.\nA rollback was performed and the old version was restored.\n[See update notes]({url}).",
       "rollback_skip": "Update to version {version} failed.\nRollback skipped, no local backup available.\n{message}.",
       "error_resolved": "All errors resolved for device {name}, ID: {id}, Sku: {sku}.",
-      "safe_mode_enabled": "Auto-enabling safe mode for device {name} (id: {id}) due to unsupported attribute."
+      "safe_mode_enabled": "Auto-enabling safe mode for device {name} (id: {id}) due to unsupported attribute.",
+      "set_attribute_failed": "Cannot set device {id} attributes: {data}. Neviweb returned: {error}."
     }
   }
 }

--- a/custom_components/neviweb130/translations/fr.json
+++ b/custom_components/neviweb130/translations/fr.json
@@ -59,7 +59,8 @@
       "update_fail": "La mise à jour vers la version {version} a échoué.\nUne restauration a été effectuée et l'ancienne version a été rétablie.\n[Voir les notes de mise à jour]({url}).",
       "rollback_skip": "La mise à jour vers la version {version} a échoué.\nRestauration ignorée, aucune sauvegarde locale disponible.\n{message}.",
       "error_resolved": "Toutes les erreurs ont été résolues pour l'appareil {name}, ID : {id}, Sku : {sku}.",
-      "safe_mode_enabled": "Activation automatique du mode sans échec pour le périphérique {name} (id : {id}) en raison d'un attribut non pris en charge."
+      "safe_mode_enabled": "Activation automatique du mode sans échec pour le périphérique {name} (id : {id}) en raison d'un attribut non pris en charge.",
+      "set_attribute_failed": "Impossible de définir les attributs de l'appareil {id} : {data}. Neviweb a répondu : {error}."
     }
   }
 }


### PR DESCRIPTION
## Résumé

Suite à l'issue #515 : `set_device_attributes` réessayait 3 fois quand l'API Neviweb répondait HTTP 200 avec un payload d'erreur (`{"error": {"code": "SVCUNAUTH"}}`), puis **retournait comme si l'écriture avait réussi**. Tous les services construits dessus (`set_backlight`, écritures de consigne, keypad lock, ...) apparaissaient comme réussis alors que l'appareil n'avait jamais reçu la commande — la seule trace était une ligne de log niveau `debug`.

## Changements

- Succès → `return` (au lieu de `break` + fin silencieuse).
- Les 3 réessais sont conservés, mais le dernier payload d'erreur est conservé (`last_error`).
- Après épuisement des réessais : `WARNING` + `raise PyNeviweb130Error` incluant le code d'erreur Neviweb, pour que les appels de service échouent visiblement et que les automatisations puissent réagir.
- Nouvelle clé de traduction `set_attribute_failed` (en + fr + strings.json).

## Reproduire le problème (avant le fix)

Appeler `neviweb130.set_backlight` avec `backlightAdaptive: on` sur un TH1400ZB : l'API répond `SVCUNAUTH`, le service « réussit », et l'attribut `backlightAdaptive` reste inchangé au sondage suivant — aucune erreur visible avec les logs par défaut.

## Testé

- `python -m py_compile` OK.
- Comportement vérifié sur mon installation (5× TH1400ZB + GT130, HA 2026.7.2, neviweb130 4.2.9) : le cas d'erreur SVCUNAUTH sur `set_backlight` était celui de l'issue #515.

Fixes #515
